### PR TITLE
properly escape chars when quoting phrase

### DIFF
--- a/lib/Email/Address.pm
+++ b/lib/Email/Address.pm
@@ -441,7 +441,7 @@ sub _enquoted_phrase {
   return $phrase if $phrase =~ /\A=\?.+\?=\z/;
 
   $phrase =~ s/\A"(.+)"\z/$1/;
-  $phrase =~ s/\"/\\"/g;
+  $phrase =~ s/([\\"])/\\$1/g;
 
   return qq{"$phrase"};
 }

--- a/t/quoting.t
+++ b/t/quoting.t
@@ -2,7 +2,7 @@
 use strict;
 
 use Email::Address;
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 my $phrase = q{jack!work};
 my $email  = 'jack@work.com';
@@ -36,3 +36,9 @@ is(
 );
 
 is($ea3->phrase, $phrase, "the phrase method returns the right thing");
+
+{
+    my $ea = Email::Address->new(q{jack "\\" robinson}, 'jack@work.com');
+    is $ea->phrase, q{jack "\\" robinson};
+    is $ea->format, q{"jack \\"\\\\\\" robinson" <jack@work.com>};
+}


### PR DESCRIPTION
Not only " should be escaped, but \ as well.

This is in conformance with RFC822 and newer versions.
