### PR TITLE
Don't warn when stringifying undef phrases (as ->parse generates)

### DIFF
--- a/lib/Email/Address.pm
+++ b/lib/Email/Address.pm
@@ -423,6 +423,8 @@ sub _enquoted_phrase {
 
   my $phrase = $self->[_PHRASE];
 
+  return '' unless defined $phrase;
+
   # if it's encoded -- rjbs, 2007-02-28
   return $phrase if $phrase =~ /\A=\?.+\?=\z/;
 


### PR DESCRIPTION
This fixes a regression in 1.899 caused by the addition of `use warnings` in 5bcb255.  Namely, the following did not warn under 1.898, but does under 1.899:

```
perl -MEmail::Address -wle 'my ($e) = Email::Address->parse(q|foo@example.com (Comment)|); print "Got |$e|"'
```

Specifically, 1.899 generates:

```
Use of uninitialized value $phrase in pattern match (m//) at lib/Email/Address.pm line 427.
Use of uninitialized value $phrase in substitution (s///) at lib/Email/Address.pm line 429.
Use of uninitialized value $phrase in substitution (s///) at lib/Email/Address.pm line 430.
Use of uninitialized value $phrase in concatenation (.) or string at lib/Email/Address.pm line 432.
Got |"" <foo@example.com> (Comment)|
```
