### PR TITLE
Improve email address parsing

### DIFF
--- a/lib/Email/Address.pm
+++ b/lib/Email/Address.pm
@@ -6,6 +6,7 @@ package Email::Address;
 our $COMMENT_NEST_LEVEL ||= 1;
 our $STRINGIFY          ||= 'format';
 our $COLLAPSE_SPACES      = 1 unless defined $COLLAPSE_SPACES; # I miss //=
+our $UNICODE            ||= 0;
 
 =head1 SYNOPSIS
 
@@ -172,9 +173,10 @@ collapse multiple spaces into a single space, which avoids this problem.  To
 prevent this behavior, set C<$Email::Address::COLLAPSE_SPACES> to zero.  This
 variable will go away when the bug is resolved properly.
 
-In accordance with RFC 822 and its descendants, this module demands that email
-addresses be ASCII only.  Any non-ASCII content in the parsed addresses will
-cause the parser to return no results.
+By default, this module mandates that email addresses be ASCII only, and any
+non-ASCII content will cause a blank result. This matches RFCs 822, 2822, and
+5322. If you wish to allow UTF-8 characters in email, as per RFCs 5335 and
+6532, set C<$Email:Address::UNICODE> to 1.
 
 =cut
 
@@ -223,8 +225,10 @@ sub parse {
           ($user, $host) = ($1, $2);
       }
 
-      next if $user =~ /\P{ASCII}/;
-      next if $host =~ /\P{ASCII}/;
+      unless ($UNICODE) {
+          next if $user =~ /\P{ASCII}/;
+          next if $host =~ /\P{ASCII}/;
+      }
 
       my ($phrase)       = /($display_name)/o;
 

--- a/lib/Email/Address.pm
+++ b/lib/Email/Address.pm
@@ -29,15 +29,13 @@ to be correct, and very very fast.
 my $CTL            = q{\x00-\x1F\x7F};
 my $special        = q{()<>\\[\\]:;@\\\\,."};
 
-my $text           = qr/[^\x0A\x0D]/;
+my $quoted_pair    = qr/\\[[:graph:] \t]/;
 
-my $quoted_pair    = qr/\\$text/;
-
-my $ctext          = qr/(?>[^()\\]+)/;
+my $ctext          = qr/[^$CTL()\\]/;
 my ($ccontent, $comment) = (q{})x2;
 for (1 .. $COMMENT_NEST_LEVEL) {
   $ccontent = qr/$ctext|$quoted_pair|$comment/;
-  $comment  = qr/\s*\((?:\s*$ccontent)*\s*\)\s*/;
+  $comment  = qr/\($ccontent*\)/;
 }
 my $cfws           = qr/$comment|\s+/;
 
@@ -46,33 +44,18 @@ my $atom           = qr/$cfws*$atext+$cfws*/;
 my $dot_atom_text  = qr/$atext+(?:\.$atext+)*/;
 my $dot_atom       = qr/$cfws*$dot_atom_text$cfws*/;
 
-my $qtext          = qr/[^\\"]/;
+my $qtext          = qr/[^$CTL\\"]/;
 my $qcontent       = qr/$qtext|$quoted_pair/;
 my $quoted_string  = qr/$cfws*"$qcontent*"$cfws*/;
 
 my $word           = qr/$atom|$quoted_string/;
 
-# XXX: This ($phrase) used to just be: my $phrase = qr/$word+/; It was changed
-# to resolve bug 22991, creating a significant slowdown.  Given current speed
-# problems.  Once 16320 is resolved, this section should be dealt with.
-# -- rjbs, 2006-11-11
-#my $obs_phrase     = qr/$word(?:$word|\.|$cfws)*/;
-
-# XXX: ...and the above solution caused endless problems (never returned) when
-# examining this address, now in a test:
-#   admin+=E6=96=B0=E5=8A=A0=E5=9D=A1_Weblog-- ATAT --test.socialtext.com
-# So we disallow the hateful CFWS in this context for now.  Of modern mail
-# agents, only Apple Web Mail 2.0 is known to produce obs-phrase.
-# -- rjbs, 2006-11-19
-my $simple_word    = qr/$atom|\.|\s*"$qcontent+"\s*/;
-my $obs_phrase     = qr/$simple_word+/;
-
+my $obs_phrase     = qr/$word(?:$word|\.|$cfws)*/;
 my $phrase         = qr/$obs_phrase|(?:$word+)/;
 
 my $local_part     = qr/$dot_atom|$quoted_string/;
-my $dtext          = qr/[^\[\]\\]/;
-my $dcontent       = qr/$dtext|$quoted_pair/;
-my $domain_literal = qr/$cfws*\[(?:\s*$dcontent)*\s*\]$cfws*/;
+my $dtext          = qr/[^$CTL\[\]\\]/;
+my $domain_literal = qr/$cfws*\[$dtext*\]$cfws*/;
 my $domain         = qr/$dot_atom|$domain_literal/;
 
 my $display_name   = $phrase;
@@ -127,7 +110,7 @@ following comment.
 our $addr_spec  = qr/$local_part\@$domain/;
 our $angle_addr = qr/$cfws*<$addr_spec>$cfws*/;
 our $name_addr  = qr/(?>$display_name?)$angle_addr/;
-our $mailbox    = qr/(?:$name_addr|$addr_spec)$comment*/;
+our $mailbox    = qr/$name_addr|$addr_spec/;
 
 sub _PHRASE   () { 0 }
 sub _ADDRESS  () { 1 }

--- a/t/ascii.t
+++ b/t/ascii.t
@@ -10,50 +10,63 @@ my $ascii = q{admin@mozilla.org};
 my $utf_8 = q{аdmin@mozilla.org};
 my $text  = decode('utf-8', $utf_8, Encode::LEAVE_SRC);
 
-my $ok_mixed  = qq{"$text" <$ascii>};
-my $bad_mixed = qq{"$text" <$text>};
+my $ascii_mixed = qq{"$text" <$ascii>};
+my $utf8_mixed = qq{"$text" <$text>};
 
-{
-  my (@addr) = Email::Address->parse($ascii);
-  is(@addr, 1, "an ascii address is a-ok");
+for (0..1) {
+  local $Email::Address::UNICODE = $_;
 
-  # ok( $ascii =~ $Email::Address::addr_spec, "...it =~ addr_spec");
-}
+  {
+    my (@addr) = Email::Address->parse($ascii);
+    is(@addr, 1, "an ascii address is a-ok");
 
-{
-  my (@addr) = Email::Address->parse($ok_mixed);
-  is(@addr, 1, "a quoted non-ascii phrase is a-ok with ascii email");
-}
+    # ok( $ascii =~ $Email::Address::addr_spec, "...it =~ addr_spec");
+  }
 
-{
-  my (@addr) = Email::Address->parse($bad_mixed);
-  is(@addr, 0, "a quoted non-ascii phrase is not okay with non-ascii email");
-}
+  {
+    my (@addr) = Email::Address->parse($ascii_mixed);
+    is(@addr, 1, "a quoted non-ascii phrase is a-ok with ascii email");
+  }
 
-{
-  my (@addr) = Email::Address->parse($utf_8);
-  is(@addr, 0, "utf-8 octet address: not ok");
+  {
+    my (@addr) = Email::Address->parse($utf8_mixed);
+    is(@addr, $Email::Address::UNICODE, "a quoted non-ascii phrase with non-ascii email");
+  }
 
-  # ok( $utf_8 !~ $Email::Address::addr_spec, "...it !~ addr_spec");
-}
+  {
+    my (@addr) = Email::Address->parse($utf_8);
+    is(@addr, $Email::Address::UNICODE, "utf-8 octet address");
 
-{
-  my (@addr) = Email::Address->parse($text);
-  is(@addr, 0, "unicode (decoded) address: not ok");
+    # ok( $utf_8 !~ $Email::Address::addr_spec, "...it !~ addr_spec");
+  }
 
-  # ok( $text =~ $Email::Address::addr_spec, "...it !~ addr_spec");
-}
+  {
+    my (@addr) = Email::Address->parse($text);
+    is(@addr, $Email::Address::UNICODE, "unicode (decoded) address");
 
-{
-  my @addr = Email::Address->parse(qq{
-    "Not ascii phras\x{e9}" <good\@email>,
-    b\x{e3}d\@user,
-    bad\@d\x{f6}main,
-    not.bad\@again
-  });
-  is scalar @addr, 2, "correct number of good emails";
-  is "$addr[0]", qq{"Not ascii phras\x{e9}" <good\@email>}, "expected email";
-  is "$addr[1]", qq{not.bad\@again}, "expected email";
+    # ok( $text =~ $Email::Address::addr_spec, "...it !~ addr_spec");
+  }
+
+  {
+    my @addr = Email::Address->parse(qq{
+      "Not ascii phras\x{e9}" <good\@email>,
+      b\x{e3}d\@user,
+      bad\@d\x{f6}main,
+      not.bad\@again
+    });
+    is scalar @addr, $Email::Address::UNICODE ? 4 : 2, "correct number of good emails";
+    is "$addr[0]", qq{"Not ascii phras\x{e9}" <good\@email>}, "expected email";
+    if ($Email::Address::UNICODE) {
+      is "$addr[1]", qq{b\x{e3}d\@user}, "expected email";
+      is "$addr[2]", qq{bad\@d\x{f6}main}, "expected email";
+      is "$addr[3]", qq{not.bad\@again}, "expected email";
+    } else {
+      is "$addr[1]", qq{not.bad\@again}, "expected email";
+    }
+  }
+
+  Email::Address->purge_cache;
+
 }
 
 done_testing;

--- a/t/speed.t
+++ b/t/speed.t
@@ -1,0 +1,15 @@
+#!perl
+use strict;
+
+use Email::Address;
+use Test::More tests => 1;
+
+my $email = "\"Hello\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\" <\@m>";
+my ($ea) = Email::Address->parse($email);
+
+is(
+  $ea,
+  undef,
+  'Bad address does not parse, but is not really slow'
+);
+

--- a/t/speed.t
+++ b/t/speed.t
@@ -2,7 +2,7 @@
 use strict;
 
 use Email::Address;
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 my $email = "\"Hello\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\" <\@m>";
 my ($ea) = Email::Address->parse($email);
@@ -13,3 +13,9 @@ is(
   'Bad address does not parse, but is not really slow'
 );
 
+my $email = '\(¯¯`·.¥«P®ÎÑç€ØfTh€ÐÅ®K»¥.·`¯¯\) <email () example com>, "(> \" \" <)                              ( =\'o\'= )                              (\")___(\")  sWeEtAnGeLtHePrInCeSsOfThEsKy" <email2 () example com>, "(i)cRiStIaN(i)" <email3 () example com>, "(S)MaNu_vuOLeAmMazZaReNimOe(*)MiAo(@)" <email4 () example com>';
+my $email2 = ", $email";
+$email = $email . ($email2 x 10);
+my @emails = Email::Address->parse($email);
+
+is(@emails, 0, 'Bad addresses do not parse, but do not take for ever');

--- a/t/tests.t
+++ b/t/tests.t
@@ -1488,7 +1488,7 @@ my @list = (
     '"Greg Norris (humble visionary genius)" <nextrightmove-- ATAT --bang.example.net>, <advocacy-- ATAT --p.example.org>',
     [
       [
-        'Greg Norris',
+        'Greg Norris ',
         'nextrightmove-- ATAT --bang.example.net',
         '(humble visionary genius)'
       ],

--- a/t/tests.t
+++ b/t/tests.t
@@ -1629,6 +1629,16 @@ my @list = (
       ],
     ],
   ],
+  [
+    q{"Matthew" <matthew-- ATAT --example.org> (Matthew (GSC))},
+    [
+      [
+        'Matthew',
+        'matthew-- ATAT --example.org',
+        'Matthew (GSC)',
+      ],
+    ],
+  ],
 );
 
 my $tests = 1;


### PR DESCRIPTION
This PR:
* Adds a variable to allow non-ASCII email address parsing (RFC5335/6532), fixing #12;
* Updates the regular expressions to be more in line with RFC5322;
* Tries to prevent backtracking regular expression explosions, fixing #10;
* Switches to regex recursion for comment nesting, fixing #11.

(#13 is already fixed).

The first three commits I think should still be fine in 5.8, but the last commit needs 5.10 due to the use of regex recursion and named references. The tests all pass; I'm not sure if that's enough to be sure these changes don't affect any parsing or have any backward incompatibility, but hopefully this is along the right lines.

To fix other bugs, such as multiple quoted strings in the display name, or comments being stripped in a quoted string, I believe it would probably be easier for the parser to move to a non-regular expression based one.