### PR TITLE
Mark deprecated in metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,3 +6,4 @@ copyright_holder = Casey West
 copyright_year   = 2004
 
 [@RJBS]
+[Deprecated]

--- a/lib/Email/Address.pm
+++ b/lib/Email/Address.pm
@@ -570,5 +570,9 @@ performance.
 Thanks to Kevin Riggle and Tatsuhiko Miyagawa for tests for annoying
 phrase-quoting bugs!
 
+=head1 SEE ALSO
+
+L<Email::Address::XS>|Email::Address::XS>
+
 =cut
 


### PR DESCRIPTION
Hi @rjbs 

As a part of PRC, I received this distribution to submit PR. Since it is clearly marked as deprecated in the pod. I decided to follow up the suggestions in the following blog by Neil Bowers to cover the missing bits.

http://neilb.org/2015/01/17/deprecated-metadata.html

Can you please review the PR?

Many Thanks.
Best Regards,
Mohammad S Anwar